### PR TITLE
Integrate CodexUI module into Kai and add GitHub Actions APK build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Android APK Build
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build release APK
+        run: gradle :app:assembleRelease
+
+      # Optional signing setup:
+      # 1) Add base64-encoded keystore to repository secrets as ANDROID_KEYSTORE_BASE64
+      # 2) Add alias/password secrets as ANDROID_KEY_ALIAS, ANDROID_KEYSTORE_PASSWORD, ANDROID_KEY_PASSWORD
+      # 3) Decode keystore and wire signingConfig in app/build.gradle.kts
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release-apk
+          path: app/build/outputs/apk/release/*.apk
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.gradle/
+.idea/
+local.properties
+**/build/
+.DS_Store

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,67 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.mankeluvsit.kaicodexui"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "com.mankeluvsit.kaicodexui"
+        minSdk = 26
+        targetSdk = 35
+        versionCode = 1
+        versionName = "1.0.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        vectorDrawables {
+            useSupportLibrary = true
+        }
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+}
+
+dependencies {
+    implementation(project(":codexui"))
+
+    val composeBom = platform("androidx.compose:compose-bom:2025.01.01")
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.activity:activity-compose:1.10.1")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Intentionally empty for now.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:allowBackup="true"
+        android:icon="@drawable/ic_launcher_foreground"
+        android:label="@string/app_name"
+        android:roundIcon="@drawable/ic_launcher_foreground"
+        android:supportsRtl="true"
+        android:theme="@android:style/Theme.Material.Light.NoActionBar">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/mankeluvsit/kaicodexui/MainActivity.kt
+++ b/app/src/main/java/com/mankeluvsit/kaicodexui/MainActivity.kt
@@ -1,0 +1,54 @@
+package com.mankeluvsit.kaicodexui
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.mankeluvsit.codexui.CodexUiScreen
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+
+        setContent {
+            var showCodexUi by rememberSaveable { mutableStateOf(false) }
+
+            MaterialTheme {
+                if (showCodexUi) {
+                    CodexUiScreen(onBack = { showCodexUi = false })
+                } else {
+                    Scaffold(modifier = Modifier.fillMaxSize()) { padding ->
+                        Column(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(padding),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.Center,
+                        ) {
+                            Text(text = stringResource(id = R.string.kai_title))
+                            Button(onClick = { showCodexUi = true }) {
+                                Text(text = stringResource(id = R.string.open_codex_ui))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#3DDC84"
+        android:pathData="M54,12A42,42 0 1,1 53.9,12z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<resources>
+    <string name="app_name">Kai CodexUI</string>
+    <string name="kai_title">Kai</string>
+    <string name="open_codex_ui">Open CodexUI</string>
+</resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    id("com.android.application") version "8.7.3" apply false
+    id("com.android.library") version "8.7.3" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
+}

--- a/codexui/build.gradle.kts
+++ b/codexui/build.gradle.kts
@@ -1,0 +1,40 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.mankeluvsit.codexui"
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 26
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+}
+
+dependencies {
+    val composeBom = platform("androidx.compose:compose-bom:2025.01.01")
+    implementation(composeBom)
+
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material:material-icons-extended")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.activity:activity-compose:1.10.1")
+    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.webkit:webkit:1.12.1")
+}

--- a/codexui/consumer-rules.pro
+++ b/codexui/consumer-rules.pro
@@ -1,0 +1,1 @@
+# No consumer rules required for this wrapper module.

--- a/codexui/src/main/AndroidManifest.xml
+++ b/codexui/src/main/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+</manifest>

--- a/codexui/src/main/java/com/mankeluvsit/codexui/CodexUiScreen.kt
+++ b/codexui/src/main/java/com/mankeluvsit/codexui/CodexUiScreen.kt
@@ -1,0 +1,71 @@
+package com.mankeluvsit.codexui
+
+import android.annotation.SuppressLint
+import android.webkit.WebChromeClient
+import android.webkit.WebSettings
+import android.webkit.WebView
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.webkit.WebViewClientCompat
+
+/**
+ * Minimal CodexUI integration wrapper.
+ *
+ * Assumption: codexUI is served by a local/remote web endpoint and should be surfaced inside Kai.
+ */
+@SuppressLint("SetJavaScriptEnabled")
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CodexUiScreen(
+    onBack: () -> Unit,
+    codexUiUrl: String = "https://github.com/friuns2/codexUI",
+) {
+    val webViewClient = remember { WebViewClientCompat() }
+
+    BackHandler(onBack = onBack)
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("CodexUI") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        AndroidView(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            factory = { context ->
+                WebView(context).apply {
+                    settings.javaScriptEnabled = true
+                    settings.domStorageEnabled = true
+                    settings.cacheMode = WebSettings.LOAD_DEFAULT
+                    webViewClient = webViewClient
+                    webChromeClient = WebChromeClient()
+                    loadUrl(codexUiUrl)
+                }
+            },
+        )
+    }
+}

--- a/codexui/src/main/res/values/strings.xml
+++ b/codexui/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="codexui_name">CodexUI</string>
+</resources>

--- a/docs/integration-report.md
+++ b/docs/integration-report.md
@@ -1,0 +1,44 @@
+# Kai + CodexUI Integration Report
+
+## Scope and assumptions
+
+Because the container cannot fetch Git repositories over HTTPS, this implementation uses a practical merge strategy:
+
+- Keep Kai-CodexUI as an Android app shell.
+- Surface CodexUI through an embedded WebView-backed Compose screen.
+- Add CodexUI as an internal Android library module (`:codexui`) to keep integration boundaries clean.
+
+## Repository analysis summary
+
+### Kai (target architecture assumptions)
+
+- Kotlin + Gradle based Android build.
+- Android entry point is an Activity with UI navigation.
+- Suitable for adding a feature module and wiring a launch action.
+
+### CodexUI (integration assumptions)
+
+- Delivered as a UI frontend that can be rendered in a web context.
+- No direct Android Activity export required if embedded via WebView.
+
+## Integration points
+
+1. `settings.gradle.kts` includes `:codexui` beside `:app`.
+2. `app/build.gradle.kts` depends on `project(":codexui")`.
+3. `MainActivity` adds a button to open CodexUI.
+4. `CodexUiScreen` composes a WebView wrapper with back navigation.
+5. `codexui` manifest adds `INTERNET` permission.
+6. GitHub Actions workflow compiles release APK and uploads artifact.
+
+## Conflict and dependency handling
+
+- Unified Kotlin (`2.0.21`) and Android Gradle Plugin (`8.7.3`) versions in root.
+- Unified compile/target SDK (`35`) across app and library.
+- Compose dependencies aligned through BOM (`2025.01.01`).
+- CodexUI-specific dependency isolated in `:codexui` (`androidx.webkit`).
+
+## Follow-up for production readiness
+
+- Replace placeholder URL in `CodexUiScreen` with your deployed CodexUI endpoint.
+- If offline/local execution is required, package static assets or run a local HTTP server.
+- Add signing config and secrets to produce signed release APKs in CI.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
+android.useAndroidX=true
+android.nonTransitiveRClass=true
+kotlin.code.style=official

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,19 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "Kai-CodexUI"
+include(":app")
+include(":codexui")


### PR DESCRIPTION
### Motivation
- Merge CodexUI into the Kai Android app as an embeddable feature and provide a CI pipeline that produces APK artifacts automatically.  
- Provide a practical integration that works without importing the full CodexUI source by surfacing it inside Kai via a WebView (placeholder URL) to keep the modules separated and simple to iterate on.

### Description
- Add a multi-module Gradle project with `:app` (host) and `:codexui` (library) including `settings.gradle.kts`, root `build.gradle.kts`, and `gradle.properties` to unify plugin/SDK/Kotlin versions.  
- Implement `MainActivity` in `app` which toggles into a new `CodexUiScreen` composable, and add `CodexUiScreen` in `:codexui` which embeds CodexUI via a `WebView` and provides back navigation.  
- Add necessary manifests and resources (`app/src/main/AndroidManifest.xml`, `codexui/src/main/AndroidManifest.xml`, strings, launcher drawable), `consumer-rules.pro`, and a documentation report `docs/integration-report.md` explaining assumptions and follow-ups.  
- Add CI workflow `.github/workflows/build.yml` that triggers on `push`/`pull_request` to `main`, sets up JDK 17 and Gradle, runs `gradle :app:assembleRelease`, and uploads the APK artifact with comments for optional keystore signing secret configuration.

### Testing
- Executed `gradle :app:assembleDebug` locally and it failed because the environment could not resolve the Android Gradle Plugin artifacts (network/plugin repository resolution blocked), so no successful local build could be produced here.  
- Created a GitHub Actions workflow that will run `gradle :app:assembleRelease` on pushes to `main` and upload the APK as an artifact if run in CI with normal network access.  
- No automated CI builds have been validated yet from this repository because the local environment lacked plugin resolution; CI validation is expected when the repository is pushed to GitHub with access to plugin repositories and (optionally) signing secrets configured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb1221a9088325b58b3d9acaca3de9)