### PR TITLE
Add Android CI workflow and integration status note

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,55 @@
+name: Android CI Build
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Grant execute permission for Gradle wrapper
+        run: chmod +x ./gradlew
+
+      - name: Build release APK (fallback to debug if signing is missing)
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ./gradlew tasks --all | grep -q "assembleRelease"; then
+            ./gradlew assembleRelease
+          else
+            ./gradlew assembleDebug
+          fi
+
+      - name: Upload APK artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: apk-artifacts
+          path: |
+            **/build/outputs/apk/release/*.apk
+            **/build/outputs/apk/debug/*.apk
+          if-no-files-found: error
+
+      # Optional signing setup (uncomment and configure when your app is ready for signed release builds):
+      #
+      # - name: Decode keystore
+      #   run: echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 -d > keystore.jks
+      #
+      # - name: Assemble signed release
+      #   run: ./gradlew assembleRelease \
+      #      -Pandroid.injected.signing.store.file=keystore.jks \
+      #      -Pandroid.injected.signing.store.password=${{ secrets.ANDROID_KEYSTORE_PASSWORD }} \
+      #      -Pandroid.injected.signing.key.alias=${{ secrets.ANDROID_KEY_ALIAS }} \
+      #      -Pandroid.injected.signing.key.password=${{ secrets.ANDROID_KEY_PASSWORD }}

--- a/INTEGRATION_STATUS.md
+++ b/INTEGRATION_STATUS.md
@@ -1,0 +1,34 @@
+# Integration status: blocked by network restrictions in execution environment
+
+I could not access the two required upstream repositories from this environment:
+
+- `https://github.com/SimonSchubert/Kai`
+- `https://github.com/friuns2/codexUI`
+
+`git clone` fails with:
+
+```text
+CONNECT tunnel failed, response 403
+```
+
+Because the target repository in this workspace was empty, a true file-level merge of Kai + CodexUI could not be performed here.
+
+## What was completed
+
+- Added a GitHub Actions workflow at `.github/workflows/build.yml` that:
+  - Triggers on push to `main` and pull requests
+  - Uses JDK 17
+  - Executes Gradle APK build (`assembleRelease` with fallback to `assembleDebug`)
+  - Uploads produced APK(s) as artifacts
+  - Includes commented signing placeholders for secrets-based release signing
+
+## Next required step (outside this restricted environment)
+
+Once network access to GitHub is available, run:
+
+1. Clone `Kai` into this repository
+2. Integrate `codexUI` into the app module (or as a dedicated feature/library module)
+3. Resolve Gradle dependency and namespace conflicts
+4. Commit the merged source files
+
+The provided CI workflow will then compile and publish APK artifacts in GitHub Actions.


### PR DESCRIPTION
### Motivation
- Provide an automated GitHub Actions CI to build APKs for this repository and record why a full merge of Kai + CodexUI could not be completed in this environment due to network restrictions.

### Description
- Added `.github/workflows/build.yml` which sets up Temurin JDK 17, grants execute permission to the Gradle wrapper, runs `./gradlew assembleRelease` with a fallback to `./gradlew assembleDebug`, uploads APK artifacts, and includes commented keystore signing placeholders, and added `INTEGRATION_STATUS.md` documenting the blocked upstream clones and next steps.

### Testing
- Automated checks run here: `git diff --cached --check` and the commit succeeded; attempts to `git clone` the upstream `Kai` and `codexUI` repos failed with `CONNECT tunnel failed, response 403`; an attempted YAML parse via Python could not run because `PyYAML` is not installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb1221a9088325b58b3d9acaca3de9)